### PR TITLE
addition of rule config_dump and run snakefmt

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -2,6 +2,9 @@ import yaml
 
 include: "rules/00_modules.smk"
 
+localrules:
+    dump_config,
+
 rule run_all:
     input:
         "results/run_config.yaml",

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,7 +1,17 @@
+import yaml
 
 include: "rules/00_modules.smk"
 
 rule run_all:
     input:
+        "results/run_config.yaml",
         [],
 
+rule dump_config:
+    output:
+        "results/run_config.yaml",
+    run:
+        runinfo = {'_timestamp': get_timestamp(), '_username': get_username()} 
+        runinfo.update(config)
+        with open (r'results/run_config.yaml', 'w') as file:
+            yaml.dump(runinfo, file)

--- a/workflow/rules/00_modules.smk
+++ b/workflow/rules/00_modules.smk
@@ -4,6 +4,6 @@ include: "commons/01_constants.smk"
 # Module containing generic
 # Python utility functions
 include: "commons/02_pyutils.smk"
-# Module containing 
+# Module containing
 # reference container location information
 include: "commons/05_refcon.smk"

--- a/workflow/rules/commons/01_constants.smk
+++ b/workflow/rules/commons/01_constants.smk
@@ -47,7 +47,9 @@ if USE_REFERENCE_CONTAINER:
             "reference container images (*.sif files)."
         )
     else:
-        DIR_REFERENCE_CONTAINER = pathlib.Path(DIR_REFERENCE_CONTAINER).resolve(strict=True)
+        DIR_REFERENCE_CONTAINER = pathlib.Path(DIR_REFERENCE_CONTAINER).resolve(
+            strict=True
+        )
 else:
     DIR_REFERENCE_CONTAINER = pathlib.Path("/")
 DIR_REFCON = DIR_REFERENCE_CONTAINER

--- a/workflow/rules/commons/02_pyutils.smk
+++ b/workflow/rules/commons/02_pyutils.smk
@@ -1,4 +1,5 @@
 import datetime
+import os
 import pathlib
 import subprocess
 import sys
@@ -12,6 +13,17 @@ def logerr(msg):
 def logout(msg):
     write_log_message(sys.stdout, "INFO", msg)
     return
+
+
+def get_username():
+    user = os.getlogin()
+    return user
+
+
+def get_timestamp():
+    # format: ISO 8601
+    ts = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+    return ts
 
 
 def write_log_message(stream, level, message):

--- a/workflow/rules/commons/02_pyutils.smk
+++ b/workflow/rules/commons/02_pyutils.smk
@@ -1,5 +1,5 @@
 import datetime
-import os
+import getpass
 import pathlib
 import subprocess
 import sys
@@ -16,7 +16,7 @@ def logout(msg):
 
 
 def get_username():
-    user = os.getlogin()
+    user = getpass.getuser()
     return user
 
 
@@ -28,7 +28,7 @@ def get_timestamp():
 
 def write_log_message(stream, level, message):
     # format: ISO 8601
-    ts = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+    ts = get_timestamp()
     fmt_msg = f"{ts} - LOG {level}\n{message.strip()}\n"
     stream.write(fmt_msg)
     return
@@ -67,7 +67,7 @@ def rsync_f2d(source_file, target_dir):
 def rsync_f2f(source_file, target_file):
     abs_source = pathlib.Path(source_file).resolve(strict=True)
     abs_target = pathlib.Path(target_file).resolve(strict=False)
-    abs_target.mkdir(parents=True, exist_ok=True)
+    abs_target.parent.mkdir(parents=True, exist_ok=True)
     rsync(str(abs_source), str(abs_target))
     return
 


### PR DESCRIPTION
The requested rule was created to write a run_config.yaml that dumps the timestamp, username, and all config files.

Additionally, `sankefmt` was run on `/workflow` to standardize the full code.