### PR TITLE
Add create manifest functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,67 +12,17 @@ In essence, the following should suffice to get started:
 3. Conda (or mamba): for automatic setup of all software dependencies
     - Note that you can run the workflow w/o Conda, but then all tools listed under `workflow/envs/*.yaml` [not `dev_env.yaml`] need to be in your `$PATH`.
 
-Internal (template) remark: adapt the above if the workflow deployment has additional requirements (e.g., Singularity).
+For a detailed setup guide, please refer to [the workflow documentation](docs/README.md).
+
+**Internal (template) remark**: adapt the above if the workflow deployment has additional requirements (e.g., Singularity).
 
 ## Required input data
 
-Add info here
+Add info here - be concise, and provide more details in [the workflow documentation](docs/README.md).
 
 ## Produced output data
 
-Add info here
-
-# Deploying the workflow on execution hardware
-
-1. run `./init.py` (requires Python3)
-    - this will create an "execution" Conda environment,
-    and a Snakemake working directory plus standard subfolders
-    one level above the repository location
-2. activate the created Conda environment: `cd .. && conda activate ./exec_env`
-3. prepare profile and configuration files as necessary, and run Snakemake
-
-
-# Developing the workflow locally
-
-1. run `./init.py --dev-only` (requires Python3)
-    - this will skip creating the workflow working directory and subfolders
-2. activate the created Conda environment: `conda activate ./dev_env`
-3. write your code, and add tests to `workflow/snaketests.smk`
-4. run tests:
-    - note that some tests may be expected to fail and may produce error messages
-    - if Snakemake reports a successful pipeline run, then all tests have succeeded
-      irrespective of log messages that look like errors
-    - if you want to test the functions loading reference data from reference containers,
-      you need to build the test container `test_v0.sif` and copy it into the
-      working directory for the workflow test run. Refer to the
-      [reference container repository](https://github.com/core-unit-bioinformatics/reference-container)
-      for build instructions.
-```bash
-# test w/o reference container
-snakemake --cores 1 \
-    --config devmode=True \
-    --directory wd/ \
-    --snakefile workflow/snaketests.smk
-
-# test w/ reference container
-# the container 'test_v0.sif' must exist
-# in the working directory: 'wd/test_v0.sif'
-snakemake --cores 1 \
-    --config devmode=True \
-    --directory wd/ \
-    --configfiles config/testing/params_refcon.yaml \
-    --snakefile workflow/snaketests.smk
-```
-    
-5. run the recommended code checks with the following tools:
-    - Python scripts:
-        - linting: `pylint <script.py>`
-        - organize imports: `isort <script.py>`
-        - code formatting: `black [--check] .`
-    - Snakemake files:
-        - linting: `snakemake --config devmode=True --lint`
-        - code formatting: `snakefmt [--check] .`
-6. after checking and standardizing your code, commit and push your changes
+Add info here - be concise, and provide more details in [the workflow documentation](docs/README.md).
 
 # Citation
 

--- a/config/testing/params_refcon.yaml
+++ b/config/testing/params_refcon.yaml
@@ -1,7 +1,7 @@
  
 reference_container_store: "."
 reference_container_names: 
-  - test_v0
+  - test_v1
 use_reference_container: True
 
 

--- a/config/testing/params_refcon.yaml
+++ b/config/testing/params_refcon.yaml
@@ -1,5 +1,5 @@
  
-reference_container_store: "../test_folder/"
+reference_container_store: "."
 reference_container_names: 
   - test_v0
 use_reference_container: True

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,124 @@
+# Documentation for Snakemake workflow NAME HERE
+
+Describe the purpose of the workflow (the big picture)
+
+## General concepts
+
+### Folder structure
+
+By following the below guides, you will end up with a Snakemake
+working directory (for short: `wd`) with the following subfolders:
+
+`wd/results/`: this folder contains final results and some workflow metadata
+and represents the only relevant output folder from the end user perspective.
+Accidentally deleting this folder after a successful pipeline run means you have to
+restart the pipeline and Snakemake will check which result files have to be recreated.
+
+`wd/proc/`: the `processing` folder contains intermediate files
+and is not of interest to end users. As a design principle, deleting this
+folder after successful pipeline execution must not result in the loss of
+any relevant data.
+
+The folders `wd/log/` (log files), `wd/rsrc/` (resource/benchmark files) and both
+reference data folders (`wd/global_ref/` and `wd/local_ref/`) should not contain
+any processed sample data (clean design), and are only relevant for workflow developers.
+
+### Accounting: the file manifest
+
+If properly set up, each workflow automatically creates a result file
+named `manifest.tsv` (in the folder `wd/results/`). This
+file lists all (i) input, (ii) reference (from `wd/global_ref/`) and (iii)
+result files together with metadata such as file size and data checksums
+(both MD5 and SHA256). This file is of utmost importance to track which
+input files in conjunction with which reference files were used to produce
+a certain set of result files. Never-ever delete this file.
+
+**Important** Preparing the computation of all checksums etc. that are needed
+to complete the file manifest, is done during a `--dryrun` of the pipeline. If you
+are sure that the pipeline will run start to finish, run Snakemake with the
+option `--dryrun` twice before actually starting the computations. This will
+ensure that all metadata files (checksums etc.) will be known to Snakemake
+when the pipeline run starts and will be created as part of the regular flow
+of computations.
+
+### Rerunning the exact same workflow
+
+By default, after a successful pipeline run, a complete dump of the workflow
+configuration is written to a file named `run_config.yaml` (in the folder
+`wd/results/`). This configuration dump includes the information which user
+executated the workflow and which (code) version of the worklow was used.
+Assuming that the execution infrastructure (i.e., the compute cluster) is
+the same, it is possible to use just this configuration file to rerun the workflow
+in the exact same way. Never-ever delete this file.
+
+## Documentation for users
+
+If you want to use this workflow as a black box to process your data,
+simply follow the below series of steps to get things up and running.
+
+### Deploying the workflow on execution hardware
+
+1. run `./init.py` (requires Python3)
+    - this will create an "execution" Conda environment,
+    and a Snakemake working directory plus standard subfolders
+    one level above the repository location
+2. activate the created Conda environment: `cd .. && conda activate ./exec_env`
+3. prepare profile and configuration files as necessary, and run Snakemake
+
+
+### Detailed output specification
+
+For detailed descriptions, this should be moved in a separate markdown file.
+
+## Documentation for developers
+
+### Developing the workflow locally
+
+1. run `./init.py --dev-only` (requires Python3)
+    - this will skip creating the workflow working directory and subfolders
+2. activate the created Conda environment: `conda activate ./dev_env`
+3. write your code, and add tests to `workflow/snaketests.smk`
+4. run tests:
+    - note that some tests may be expected to fail and may produce error messages
+    - if Snakemake reports a successful pipeline run, then all tests have succeeded
+      irrespective of log messages that look like errors
+    - if you want to test the functions loading reference data from reference containers,
+      you need to build the test container `test_v0.sif` and copy it into the
+      working directory for the workflow test run. Refer to the
+      [reference container repository](https://github.com/core-unit-bioinformatics/reference-container)
+      for build instructions.
+
+```bash
+# Example: test w/o reference container
+# Note: execute the workflow first in
+# '--dryrun' mode to trigger (and test)
+# the complete MANIFEST creation
+snakemake --cores 1 \
+    [--dryrun] \
+    --config devmode=True \
+    --directory wd/ \
+    --snakefile workflow/snaketests.smk
+
+# Example: test w/ reference container;
+# the container 'test_v0.sif' must exist
+# in the working directory: 'wd/test_v0.sif'
+# Note: execute the workflow first in
+# '--dryrun' mode to trigger (and test)
+# the complete MANIFEST creation
+snakemake --cores 1 \
+    [--dryrun] \
+    --config devmode=True \
+    --directory wd/ \
+    --configfiles config/testing/params_refcon.yaml \
+    --snakefile workflow/snaketests.smk
+```
+    
+5. run the recommended code checks with the following tools:
+    - Python scripts:
+        - linting: `pylint <script.py>`
+        - organize imports: `isort <script.py>`
+        - code formatting: `black [--check] .`
+    - Snakemake files:
+        - linting: `snakemake --config devmode=True --lint`
+        - code formatting: `snakefmt [--check] .`
+6. after checking and standardizing your code, commit and push your changes

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -9,7 +9,6 @@ rule run_all:
         # add output of final rule(s) here
         # to trigger complete run
         [],
-        
 
 
 onsuccess:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,10 +1,15 @@
+include: "rules/commons/00_commons.smk"
 include: "rules/00_modules.smk"
 
 
 rule run_all:
     input:
         RUN_CONFIG_RELPATH,
+        MANIFEST_RELPATH,
+        # add output of final rule(s) here
+        # to trigger complete run
         [],
+        
 
 
 onsuccess:

--- a/workflow/envs/dev_env.yaml
+++ b/workflow/envs/dev_env.yaml
@@ -3,7 +3,8 @@ dependencies:
   - Python=3.9.*
   - pip
   - mamba=0.25.0
-  - snakemake=7.12.0
+  - snakemake=7.14.0
+  - portalocker=2.5.1
   - pandas=1.4.3
   - pytables=3.7.0
   - hdf5=1.12.1

--- a/workflow/envs/exec_env.yaml
+++ b/workflow/envs/exec_env.yaml
@@ -3,7 +3,8 @@ dependencies:
   - Python=3.9.*
   - pip
   - mamba=0.25.0
-  - snakemake=7.12.0
+  - snakemake=7.14.0
+  - portalocker=2.5.1
   - pandas=1.4.3
   - pytables=3.7.0
   - hdf5=1.12.1

--- a/workflow/rules/00_modules.smk
+++ b/workflow/rules/00_modules.smk
@@ -1,12 +1,6 @@
-# some constants built from the Snakemake
-# command line arguments
-include: "commons/01_constants.smk"
-# Module containing generic
-# Python utility functions
-include: "commons/02_pyutils.smk"
-# Module containing generic
-# Snakemake utility rules, e.g., dump_config
-include: "commons/03_smkutils.smk"
-# Module containing
-# reference container location information
-include: "commons/05_refcon.smk"
+"""
+Use this module to list all includes
+required for your pipeline - do not
+add your pipeline-specific modules
+to "commons/00_commons.smk"
+"""

--- a/workflow/rules/commons/00_commons.smk
+++ b/workflow/rules/commons/00_commons.smk
@@ -1,0 +1,16 @@
+# some constants built from the Snakemake
+# command line arguments
+include: "01_constants.smk"
+# Module containing generic
+# Python utility functions
+include: "02_pyutils.smk"
+# Module containing generic
+# Snakemake utility rules, e.g., dump_config
+include: "03_smkutils.smk"
+# Module containing
+# reference container location information
+include: "05_refcon.smk"
+# Module performing state/env-altering
+# operations before Snakemake starts its
+# actual work
+include: "09_staging.smk"

--- a/workflow/rules/commons/02_pyutils.smk
+++ b/workflow/rules/commons/02_pyutils.smk
@@ -1,12 +1,28 @@
 import datetime
 import getpass
 import pathlib
+import pickle
 import subprocess
 import sys
+import hashlib
+
+# needed to handle reference container
+# manifest cache files
+import pandas
+
+# locking capability potentially
+# needed for file accounting;
+# in the current implementation
+# (only update during dry run)
+# probably not needed
+import portalocker
 
 
 def logerr(msg):
-    write_log_message(sys.stderr, "ERROR", msg)
+    level = "ERROR"
+    if VERBOSE:
+        level = "VERBOSE (err/dbg)"
+    write_log_message(sys.stderr, level, msg)
     return
 
 
@@ -56,6 +72,246 @@ def find_script(script_name, extension="py"):
     return selected_script
 
 
+def flatten_nested_paths(struct):
+    """
+    Given an arbitrarily nested structure
+    of items presumed to be Paths, return
+    a flattened version containing only
+    pathlib.Path objects.
+    """
+
+    flattened = set()
+    for item in struct:
+        if isinstance(item, str):
+            flattened.add(pathlib.Path(item))
+        elif isinstance(item, pathlib.Path):
+            flattened.add(item)
+        elif hasattr(item, "__iter__"):
+            flattened = flattened.union(flatten_nested_paths(item))
+        else:
+            raise ValueError(f"Cannot handle item: {item}")
+    return sorted(flattened)
+
+
+# ==============================================
+# Below: utility functions for file accounting
+# ==============================================
+
+
+def _add_file_to_account(accounting_file, fmt_records):
+    """
+    Add registered files to the respective accounting file;
+    do not duplicate records by caching the set of known path
+    ids in a separate (pickle dump) file.
+    """
+    lockfile = pathlib.Path(accounting_file).with_suffix(".lock")
+    path_id_file = pathlib.Path(accounting_file).with_suffix(".paths.pck")
+    with portalocker.Lock(lockfile, "a", timeout=WAIT_ACC_LOCK_SECS) as lock:
+        try:
+            with open(path_id_file, "rb") as path_id_dump:
+                known_path_ids = pickle.load(path_id_dump)
+        except (FileNotFoundError, EOFError):
+            known_path_ids = set()
+
+        with open(accounting_file, "a") as account:
+            for path_id, path_records in fmt_records:
+                if path_id in known_path_ids:
+                    continue
+                _ = account.write(path_records)
+                known_path_ids.add(path_id)
+
+        with open(path_id_file, "wb") as path_id_dump:
+            _ = pickle.dump(known_path_ids, path_id_dump)
+    return
+
+
+def _add_checksum_files(add_files, subfolder):
+    """
+    Augment each file registered for manifest inclusion
+    with three additional files recording md5 and sha256
+    checksums and the file size in bytes.
+    """
+    formatted_records = []
+    for add_file in add_files:
+        file_name = add_file.name
+        abspath = str(add_file.resolve(strict=False))
+        path_id = hashlib.md5(abspath.encode("utf-8")).hexdigest()
+        md5_checksum = DIR_PROC.joinpath(
+            ".accounting", "checksums", f"{subfolder}", f"{file_name}.{path_id}.md5"
+        )
+        sha256_checksum = DIR_PROC.joinpath(
+            ".accounting", "checksums", f"{subfolder}", f"{file_name}.{path_id}.sha256"
+        )
+        size_file = DIR_PROC.joinpath(
+            ".accounting", "file_sizes", f"{subfolder}", f"{file_name}.{path_id}.bytes"
+        )
+        formatted_records.append(
+            (
+                path_id,
+                f"{add_file}\t{path_id}\t{subfolder}\tdata\n"
+                + f"{md5_checksum}\t{path_id}\t{subfolder}\tchecksum\n"
+                + f"{sha256_checksum}\t{path_id}\t{subfolder}\tchecksum\n"
+                + f"{size_file}\t{path_id}\t{subfolder}\tsize\n",
+            )
+        )
+
+    return formatted_records
+
+
+def register_input(*args, allow_non_existing=False):
+    """
+    This register function has slightly
+    different semantics because input files
+    should always exist when the workflow starts.
+    For special cases, a keyword-only argument can
+    be set to accept non-existing files when the
+    pipeline run starts and yet the files should
+    be counted as input files. One of those
+    special cases is the config dump, which is
+    counted as part of the input (cannot run
+    the workflow w/o config), but the dump
+    is only created after execution.
+
+    Note: the return value must be constant to
+    avoid that Snakemake triggers a rerun b/c
+    of a changed rule parameter
+    """
+    if DRYRUN:
+        accounting_file = ACCOUNTING_FILES["inputs"]
+        input_files = flatten_nested_paths(args)
+        if not allow_non_existing:
+            err_msg = ""
+            for file_path in input_files:
+                if not file_path.exists():
+                    err_msg += (
+                        f"register_input() -> input file does not exist: {file_path}\n"
+                    )
+                elif file_path.is_dir():
+                    err_msg += f"Specified input is not a regular file: {file_path}\n"
+                else:
+                    pass
+            if err_msg:
+                err_msg = f"\nINPUT ERROR:\n{err_msg}"
+                logerr(err_msg)
+                raise RuntimeError("Bad input files detected (see above)")
+        fmt_records = _add_checksum_files(input_files, "inputs")
+        _add_file_to_account(accounting_file, fmt_records)
+    return None
+
+
+def register_reference(*args):
+    """
+    See note in "register_input" regarding
+    return value; same here.
+    """
+    if DRYRUN:
+        accounting_file = ACCOUNTING_FILES["references"]
+        reference_files = flatten_nested_paths(args)
+        fmt_records = _add_checksum_files(reference_files, "references")
+        _add_file_to_account(accounting_file, fmt_records)
+    return None
+
+
+def register_result(*args):
+    """
+    See note in "register_input" regarding
+    return value; same here.
+    """
+    if DRYRUN:
+        accounting_file = ACCOUNTING_FILES["results"]
+        result_files = flatten_nested_paths(args)
+        fmt_records = _add_checksum_files(result_files, "results")
+        _add_file_to_account(accounting_file, fmt_records)
+    return None
+
+
+def load_accounting_information(wildcards):
+    """
+    This function loads the file paths from all
+    three accounting files to force creation
+    (relevant for checksum and size files).
+    """
+    created_files = []
+    for account_name, account_file in ACCOUNTING_FILES.items():
+        if VERBOSE:
+            logerr(f"Loading file account {account_name}")
+        try:
+            with open(account_file, "r") as account:
+                created_files.extend(
+                    [l.split()[0] for l in account.readlines() if l.strip()]
+                )
+            if VERBOSE:
+                logerr(f"Size of accounting file list: {len(created_files)}")
+        except FileNotFoundError:
+            if VERBOSE:
+                logerr(f"Accounting file does not exist (yet): {account_file}")
+    return sorted(created_files)
+
+
+def load_file_by_path_id(wildcards):
+    """ """
+    account_type = wildcards.file_type
+    assert account_type in ACCOUNTING_FILES
+    account_file = ACCOUNTING_FILES[account_type]
+
+    req_path_id = wildcards.path_id
+    req_file = None
+    with open(account_file, "r") as account:
+        for line in account:
+            # note here: the data file is always
+            # first in the list of four entries
+            file_path, file_path_id = line.split()[:2]
+            if file_path_id != req_path_id:
+                continue
+            req_file = file_path
+            break
+    if req_file is None:
+        logerr(
+            f"Failed loading file with path ID {req_path_id} from accounting file {account_file}"
+        )
+        raise FileNotFoundError(
+            f"Missing file: {wildcards.file_type} / {wildcards.file_name}"
+        )
+
+    return req_file
+
+
+def _load_data_line(file_path):
+    with open(file_path, "r") as dump:
+        content = dump.readline().strip().split()[0]
+    return content
+
+
+def process_accounting_record(line):
+    """ """
+    path, path_id, file_category, record_type = line.strip().split()
+    if record_type == "data":
+        record = {
+            "file_path": path,
+            "file_name": pathlib.Path(path).name,
+            "file_category": file_category,
+            "path_id": path_id,
+        }
+    elif record_type == "checksum":
+        checksum_type = path.rsplit(".", 1)[-1]
+        record = {
+            f"file_checksum_{checksum_type}": _load_data_line(path),
+            "path_id": path_id,
+        }
+    elif record_type == "size":
+        size_unit = path.rsplit(".", 1)[-1]
+        record = {
+            f"file_size_{size_unit}": int(_load_data_line(path)),
+            "path_id": path_id,
+        }
+    return path_id, record
+
+
+# ==============================================
+# Below: utility functions for file copying
+# ==============================================
+
+
 def rsync_f2d(source_file, target_dir):
     """
     Convenience function to 'rsync' a source
@@ -99,13 +355,18 @@ def _rsync(source, target):
     return
 
 
+# ==============================================
+# Below: utility functions for git interaction
+# ==============================================
+
+
 def _check_git_available():
 
     try:
         git_version = subprocess.check_output("git --version", shell=True)
         git_version = git_version.decode().strip()
         if VERBOSE:
-            logerr(f"DEBUG: git version {git_version} detectedin $PATH")
+            logerr(f"DEBUG: git version {git_version} detected in $PATH")
         git_in_path = True
     except subprocess.CalledProcessError:
         git_in_path = False
@@ -215,3 +476,144 @@ def collect_git_labels():
     git_labels = [(k, v) for k, v in label_collection.items()]
 
     return git_labels
+
+
+# =======================================================
+# Below: utility functions to handle reference container
+# manifest caching
+# =======================================================
+
+
+def refcon_find_container(manifest_cache, ref_filename):
+
+    if not pathlib.Path(manifest_cache).is_file():
+        if DRYRUN:
+            return ""
+        else:
+            raise FileNotFoundError(
+                f"Reference container manifest cache does not exist: {manifest_cache}"
+            )
+
+
+    manifests = pandas.read_csv(manifest_cache, sep="\t", header=0)
+
+    refcon_names = sorted(manifests["refcon_name"].unique())
+
+    matched_names = set(manifests.loc[manifests["name"] == ref_filename, "refcon_name"])
+    matched_alias1 = set(
+        manifests.loc[manifests["alias1"] == ref_filename, "refcon_name"]
+    )
+    matched_alias2 = set(
+        manifests.loc[manifests["alias2"] == ref_filename, "refcon_name"]
+    )
+
+    select_container = sorted(matched_names.union(matched_alias1, matched_alias2))
+    if len(select_container) > 1:
+        raise ValueError(
+            f'The requested reference file name "{ref_filename}" exists in multiple containers: {select_container}'
+        )
+    elif len(select_container) == 0:
+        raise ValueError(
+            f'The requested reference file name "{ref_filename}" exists in none of these containers: {refcon_names}'
+        )
+    else:
+        pass
+    container_path = DIR_REFCON.joinpath(select_container[0] + ".sif")
+    return container_path
+
+
+def load_reference_container_names():
+
+    existing_container = [sif_file.stem for sif_file in DIR_REFCON.glob("*.sif")]
+    requested_container = config.get("reference_container_names", [])
+    if not requested_container:
+        raise ValueError(
+            "The config option 'use_reference_container' is set to True. "
+            "Consequently, you need to specify a list of container names "
+            "in the config with the option 'reference_container_names'."
+        )
+    missing_container = ""
+    for req_con in requested_container:
+        if req_con not in existing_container:
+            missing_container += f"\nMissing reference container: {req_con}"
+            missing_container += f"\nExpected container image location: {DIR_REFCON.joinpath(req_con)}.sif\n"
+
+    if missing_container:
+        logerr(missing_container)
+        raise ValueError(
+            "At least one of the specified reference containers "
+            "(option 'reference_container_names' in the config) "
+            "does not exist in the reference container store."
+        )
+    return sorted(requested_container)
+
+
+# ==============================================
+# Below: utility functions for workflow staging
+# ==============================================
+
+
+def _extract_and_set_dryrun_constant():
+    """
+    The state of the '--dryrun' option is only available
+    when parsing the original invocation command line.
+    This function mimicks the respective code block
+    in snakemake.__init__.py::main() (first few lines)
+    """
+
+    from snakemake import get_argument_parser as get_smk_cli_parser
+
+    smk_cli_parser = get_smk_cli_parser()
+    args, _ = smk_cli_parser.parse_known_args(sys.argv)
+
+    cli_dryrun = args.dryrun
+    assert isinstance(cli_dryrun, bool)
+
+    # seems extremely unlikely to set the dryrun option as part
+    # of an execution profile, so this just issues a warning if
+    # VERBOSE is set
+    if args.profile and VERBOSE:
+        warning_msg = "\nWARNING (staging): the current value of option '--dryrun' "
+        warning_msg += f"is set to {cli_dryrun}.\nThe '--profile' may override "
+        warning_msg += "that value, but if so, this is ignored.\nWorkflow staging "
+        warning_msg += f"proceeds with '--dry-run' set to {cli_dryrun}.\n"
+        logerr(warning_msg)
+
+    global DRYRUN
+    DRYRUN = cli_dryrun
+
+    return
+
+
+def _reset_file_accounts():
+    """
+    In case erroneous entries in any of the
+    file account prevent a proper execution
+    of the pipeline, this function can be
+    triggered by setting --config resetacc=True,
+    and will delete the accounting files. Next,
+    the workflow should be re-executed with
+    `--dryrun` to recreate the accounting files.
+    """
+    if RESET_ACCOUNTING:
+        for acc_name, acc_path in ACCOUNTING_FILES.items():
+            if VERBOSE:
+                logerr(f"Resetting accounting file {acc_name}")
+            try:
+                with open(acc_path, "w"):
+                    pass
+            except FileNotFoundError:
+                pass
+            # important: reset cached path IDs
+            path_id_cache = pathlib.Path(acc_path).with_suffix(".paths.pck")
+            try:
+                with open(path_id_cache, "w"):
+                    pass
+            except FileNotFoundError:
+                pass
+
+    for acc_file_path in ACCOUNTING_FILES.values():
+        acc_path = pathlib.Path(acc_file_path).parent
+        acc_path.mkdir(exist_ok=True, parents=True)
+
+    return

--- a/workflow/rules/commons/03_smkutils.smk
+++ b/workflow/rules/commons/03_smkutils.smk
@@ -1,11 +1,72 @@
 
 localrules:
     dump_config,
+    create_manifest,
+
+
+rule accounting_file_md5_size:
+    """
+    Compute MD5 checksum and file size
+    for accounted files (inputs, references, results).
+    For convenience, this rule also computes the file
+    size to avoid this overhead at some other place
+    of the pipeline.
+    """
+    input:
+        source=load_file_by_path_id,
+    output:
+        md5=DIR_PROC.joinpath(
+            ".accounting", "checksums", "{file_type}", "{file_name}.{path_id}.md5"
+        ),
+        file_size=DIR_PROC.joinpath(
+            ".accounting", "file_sizes", "{file_type}", "{file_name}.{path_id}.bytes"
+        ),
+    benchmark:
+        DIR_RSRC.joinpath(
+            ".accounting", "checksums", "{file_type}", "{file_name}.{path_id}.md5.rsrc"
+        )
+    wildcard_constraints:
+        file_type="(" + "|".join(sorted(ACCOUNTING_FILES.keys())) + ")",
+    resources:
+        time_hrs=lambda wildcards, attempt: 1 * attempt,
+        mem_gb=lambda wildcards, attempt: 1 * attempt,
+    shell:
+        "md5sum {input.source} > {output.md5}"
+        " && "
+        "stat -c %s {input.source} > {output.file_size}"
+
+
+rule accounting_file_sha256:
+    """
+    Compute SHA256 checksum (same as for MD5)
+    """
+    input:
+        source=load_file_by_path_id,
+    output:
+        sha256=DIR_PROC.joinpath(
+            ".accounting", "checksums", "{file_type}", "{file_name}.{path_id}.sha256"
+        ),
+    benchmark:
+        DIR_RSRC.joinpath(
+            ".accounting",
+            "checksums",
+            "{file_type}",
+            "{file_name}.{path_id}.sha256.rsrc",
+        )
+    wildcard_constraints:
+        file_type="(" + "|".join(sorted(ACCOUNTING_FILES.keys())) + ")",
+    resources:
+        time_hrs=lambda wildcards, attempt: 1 * attempt,
+        mem_gb=lambda wildcards, attempt: 1 * attempt,
+    shell:
+        "sha256sum {input.source} > {output.sha256}"
 
 
 rule dump_config:
     output:
         RUN_CONFIG_RELPATH,
+    params:
+        acc_in=lambda wildcards, output: register_input(output, allow_non_existing=True),
     run:
         import yaml
 
@@ -15,11 +76,45 @@ rule dump_config:
             runinfo[f"_{label}"] = value
         # add complete Snakemake config
         runinfo.update(config)
-        try:
-            del runinfo["devmode"]
-        except KeyError:
-            pass
+        for special_key in ["devmode", "resetacc"]:
+            try:
+                del runinfo[special_key]
+            except KeyError:
+                pass
 
         with open(RUN_CONFIG_RELPATH, "w", encoding="ascii") as cfg_dump:
             yaml.dump(runinfo, cfg_dump, allow_unicode=False, encoding="ascii")
+        # END OF RUN BLOCK
+
+
+
+rule create_manifest:
+    input:
+        manifest_files=load_accounting_information,
+    output:
+        manifest=MANIFEST_RELPATH,
+    run:
+        import fileinput
+        import collections
+        import pandas
+
+        records = collections.defaultdict(dict)
+        for line in fileinput.input(ACCOUNTING_FILES.values(), mode="r"):
+            path_id, path_record = process_accounting_record(line)
+            records[path_id].update(path_record)
+
+        df = pandas.DataFrame.from_records(list(records.values()))
+        df.sort_values(["file_category", "file_name"], ascending=True)
+        reordered_columns = [
+            "file_name",
+            "file_category",
+            "file_size_bytes",
+            "file_checksum_md5",
+            "file_checksum_sha256",
+            "file_path",
+            "path_id",
+        ]
+        assert all(c in df.columns for c in reordered_columns)
+        df = df[reordered_columns]
+        df.to_csv(output.manifest, header=True, index=False, sep="\t")
         # END OF RUN BLOCK

--- a/workflow/rules/commons/05_refcon.smk
+++ b/workflow/rules/commons/05_refcon.smk
@@ -1,65 +1,3 @@
-import pandas
-
-
-def refcon_find_container(manifest_cache, ref_filename):
-
-    if not pathlib.Path(manifest_cache).is_file():
-        # could be a dry run
-        return "No-manifest-cache-available"
-
-    manifests = pandas.read_csv(manifest_cache, sep="\t", header=0)
-
-    refcon_names = sorted(manifests["refcon_name"].unique())
-
-    matched_names = set(manifests.loc[manifests["name"] == ref_filename, "refcon_name"])
-    matched_alias1 = set(
-        manifests.loc[manifests["alias1"] == ref_filename, "refcon_name"]
-    )
-    matched_alias2 = set(
-        manifests.loc[manifests["alias2"] == ref_filename, "refcon_name"]
-    )
-
-    select_container = sorted(matched_names.union(matched_alias1, matched_alias2))
-    if len(select_container) > 1:
-        raise ValueError(
-            f'The requested reference file name "{ref_filename}" exists in multiple containers: {select_container}'
-        )
-    elif len(select_container) == 0:
-        raise ValueError(
-            f'The requested reference file name "{ref_filename}" exists in none of these containers: {refcon_names}'
-        )
-    else:
-        pass
-    container_path = DIR_REFCON.joinpath(select_container[0] + ".sif")
-    return container_path
-
-
-def load_reference_container_names():
-
-    existing_container = [sif_file.stem for sif_file in DIR_REFCON.glob("*.sif")]
-    requested_container = config.get("reference_container_names", [])
-    if not requested_container:
-        raise ValueError(
-            "The config option 'use_reference_container' is set to True. "
-            "Consequently, you need to specify a list of container names "
-            "in the config with the option 'reference_container_names'."
-        )
-    missing_container = ""
-    for req_con in requested_container:
-        if req_con not in existing_container:
-            missing_container += f"\nMissing reference container: {req_con}"
-            missing_container += f"\nExpected container image location: {DIR_REFCON.joinpath(req_con)}.sif\n"
-
-    if missing_container:
-        logerr(missing_container)
-        raise ValueError(
-            "At least one of the specified reference containers "
-            "(option 'reference_container_names' in the config) "
-            "does not exist in the reference container store."
-        )
-    return sorted(requested_container)
-
-
 if USE_REFERENCE_CONTAINER:
 
     localrules:
@@ -70,11 +8,12 @@ if USE_REFERENCE_CONTAINER:
         input:
             sif=DIR_REFCON.joinpath("{refcon_name}.sif"),
         output:
-            manifest="cache/refcon/{refcon_name}.manifest",
+            manifest=DIR_PROC.joinpath(".cache", "refcon", "{refcon_name}.manifest"),
         envmodules:
             ENV_MODULE_SINGULARITY,
         shell:
             "{input.sif} manifest > {output.manifest}"
+
 
     rule refcon_run_get_file:
         """
@@ -87,7 +26,7 @@ if USE_REFERENCE_CONTAINER:
         (i.e., treat them like a regular file)
         """
         input:
-            cache="cache/refcon/refcon_manifests.cache",
+            cache=DIR_PROC.joinpath(".cache", "refcon", "refcon_manifests.cache"),
         output:
             DIR_GLOBAL_REF.joinpath("{filename}"),
         envmodules:
@@ -96,18 +35,22 @@ if USE_REFERENCE_CONTAINER:
             refcon_path=lambda wildcards, input: refcon_find_container(
                 input.cache, wildcards.filename
             ),
+            acc_ref=lambda wildcards, output: register_reference(output),
         shell:
             "{params.refcon_path} get {wildcards.filename} {output}"
+
 
     rule refcon_cache_manifests:
         input:
             manifests=expand(
-                "cache/refcon/{refcon_name}.manifest",
+                DIR_PROC.joinpath(".cache", "refcon", "{refcon_name}.manifest"),
                 refcon_name=load_reference_container_names(),
             ),
         output:
-            cache="cache/refcon/refcon_manifests.cache",
+            cache=DIR_PROC.joinpath(".cache", "refcon", "refcon_manifests.cache"),
         run:
+            import pandas
+
             merged_manifests = []
             for manifest_file in input.manifests:
                 container_name = pathlib.Path(manifest_file).stem

--- a/workflow/rules/commons/05_refcon.smk
+++ b/workflow/rules/commons/05_refcon.smk
@@ -14,7 +14,6 @@ if USE_REFERENCE_CONTAINER:
         shell:
             "{input.sif} manifest > {output.manifest}"
 
-
     rule refcon_run_get_file:
         """
         Snakemake interacts with Singularity containers using "exec",
@@ -26,7 +25,7 @@ if USE_REFERENCE_CONTAINER:
         (i.e., treat them like a regular file)
         """
         input:
-            cache=DIR_PROC.joinpath(".cache", "refcon", "refcon_manifests.cache"),
+            cache=trigger_refcon_manifest_caching,
         output:
             DIR_GLOBAL_REF.joinpath("{filename}"),
         envmodules:
@@ -39,8 +38,7 @@ if USE_REFERENCE_CONTAINER:
         shell:
             "{params.refcon_path} get {wildcards.filename} {output}"
 
-
-    rule refcon_cache_manifests:
+    checkpoint refcon_cache_manifests:
         input:
             manifests=expand(
                 DIR_PROC.joinpath(".cache", "refcon", "{refcon_name}.manifest"),

--- a/workflow/rules/commons/09_staging.smk
+++ b/workflow/rules/commons/09_staging.smk
@@ -1,0 +1,25 @@
+"""
+The staging module is the right place to trigger
+code executions that affect the state/env
+the workflow is executed in and that need
+to be executed before Snakemake starts
+its actual work.
+
+This is the only "commons" module that is
+dependent on the other "commons" modules.
+In other words, here, the series of
+"include:" statements in "00_commons.smk"
+matters.
+
+Functions called here should be written
+in a very defensive manner, and always
+be tested in some way via "snaketests.smk"
+"""
+
+# Set the value of the constant DRYRUN
+_extract_and_set_dryrun_constant()
+assert DRYRUN is not None
+assert isinstance(DRYRUN, bool)
+
+# reset accounting files if requested
+_reset_file_accounts()

--- a/workflow/snaketests.smk
+++ b/workflow/snaketests.smk
@@ -31,6 +31,7 @@ rule create_test_file:
         # END OF RUN BLOCK
 
 
+
 rule test_log_functions:
     """
     Test pyutil logging functions
@@ -51,6 +52,7 @@ rule test_log_functions:
         # END OF RUN BLOCK
 
 
+
 rule test_find_script_success:
     input:
         expand(rules.test_log_functions.output, logtype=["err", "out"]),
@@ -67,6 +69,7 @@ rule test_find_script_success:
         with open(output[0], "w") as testfile:
             testfile.write("find_script success test ok")
         # END OF RUN BLOCK
+
 
 
 rule test_find_script_fail:
@@ -88,6 +91,7 @@ rule test_find_script_fail:
         # END OF RUN BLOCK
 
 
+
 rule test_rsync_f2d:
     input:
         rules.create_test_file.output,
@@ -106,6 +110,7 @@ rule test_rsync_f2d:
         # END OF RUN BLOCK
 
 
+
 rule test_rsync_f2f:
     input:
         rules.create_test_file.output,
@@ -116,6 +121,7 @@ rule test_rsync_f2f:
     run:
         rsync_f2f(input[0], output[0])
         # END OF RUN BLOCK
+
 
 
 rule test_rsync_fail:
@@ -138,6 +144,7 @@ rule test_rsync_fail:
         # END OF RUN BLOCK
 
 
+
 rule test_git_labels:
     input:
         rules.test_rsync_f2d.output,
@@ -155,15 +162,18 @@ rule test_git_labels:
         # END OF RUN BLOCK
 
 
+
 if USE_REFERENCE_CONTAINER:
     CONTAINER_TEST_FILES = [
         DIR_GLOBAL_REF.joinpath("genome.fasta.fai"),
+        DIR_GLOBAL_REF.joinpath("exclusions.bed"),
+        DIR_GLOBAL_REF.joinpath("hg38_full.fasta.fai"),
         DIR_PROC.joinpath(".cache", "refcon", "refcon_manifests.cache"),
     ]
-    REGISTER_REFERENCE_FILE = CONTAINER_TEST_FILES[0]
+    REGISTER_REFERENCE_FILES = CONTAINER_TEST_FILES[:3]
 else:
     CONTAINER_TEST_FILES = []
-    REGISTER_REFERENCE_FILE = []
+    REGISTER_REFERENCE_FILES = []
 
 
 rule trigger_tests:
@@ -174,7 +184,7 @@ rule trigger_tests:
         DIR_RES.joinpath("testing", "all-ok.txt"),
     params:
         acc_out=lambda wildcards, output: register_result(output),
-        acc_ref=lambda wildcards, input: register_reference(REGISTER_REFERENCE_FILE),
+        acc_ref=lambda wildcards, input: register_reference(REGISTER_REFERENCE_FILES),
     run:
         with open(output[0], "w") as testfile:
             testfile.write("ok")

--- a/workflow/snaketests.smk
+++ b/workflow/snaketests.smk
@@ -1,9 +1,11 @@
+include: "rules/commons/00_commons.smk"
 include: "rules/00_modules.smk"
 
 
 rule run_tests:
     input:
         RUN_CONFIG_RELPATH,
+        MANIFEST_RELPATH,
         DIR_RES.joinpath("testing", "all-ok.txt"),
 
 
@@ -15,6 +17,8 @@ rule create_test_file:
     """
     output:
         DIR_PROC.joinpath("testing", "ts-ok_user-ok.txt"),
+    params:
+        acc_in=lambda wildcards, output: register_input(output, allow_non_existing=True),
     run:
         timestamp = get_timestamp()
         user_id = get_username()
@@ -22,9 +26,9 @@ rule create_test_file:
         content += f"get_username: {user_id}\n"
         content += f"get_timestamp: {timestamp}\n"
         with open(output[0], "w") as testfile:
-            testfile.write(content)
+            _ = testfile.write(content)
+            _ = testfile.write("Creating test input file succeeded")
         # END OF RUN BLOCK
-
 
 
 rule test_log_functions:
@@ -32,21 +36,30 @@ rule test_log_functions:
     Test pyutil logging functions
     """
     output:
-        DIR_PROC.joinpath("testing", "log-ok.txt"),
+        DIR_PROC.joinpath("testing", "log-{logtype}-ok.txt"),
+    params:
+        acc_out=lambda wildcards, output: register_result(output),
     run:
-        logout("Test log message to STDOUT")
-        logerr("Test log message to STDERR")
+        if wildcards.logtype == "out":
+            logout("Test log message to STDOUT")
+        elif wildcards.logtype == "err":
+            logerr("Test log message to STDERR")
+        else:
+            raise ValueError(f"Unknown log type: {wildcards.logtype}")
         with open(output[0], "w") as testfile:
-            testfile.write("Log test ok")
+            testfile.write(f"Log test {wildcards.logtype} ok")
         # END OF RUN BLOCK
 
 
-
 rule test_find_script_success:
+    input:
+        expand(rules.test_log_functions.output, logtype=["err", "out"]),
+        rules.create_test_file.output,
     output:
         DIR_PROC.joinpath("testing", "success-find-script-ok.txt"),
     params:
         script=find_script("test"),
+        acc_out=lambda wildcards, output: register_result(output),
     run:
         # the following should never raise,
         # i.e. script_find() would fail before
@@ -56,10 +69,13 @@ rule test_find_script_success:
         # END OF RUN BLOCK
 
 
-
 rule test_find_script_fail:
+    input:
+        rules.test_find_script_success.output,
     output:
         DIR_PROC.joinpath("testing", "fail-find-script-ok.txt"),
+    params:
+        acc_out=lambda wildcards, output: register_result(output),
     run:
         try:
             script = find_script("non_existing")
@@ -72,12 +88,14 @@ rule test_find_script_fail:
         # END OF RUN BLOCK
 
 
-
 rule test_rsync_f2d:
     input:
         rules.create_test_file.output,
+        rules.test_find_script_fail.output,
     output:
         DIR_PROC.joinpath("testing", "subfolder", "ts-ok_user-ok.txt"),
+    params:
+        acc_out=lambda wildcards, output: register_result(output),
     run:
         # first check that nobody changed the filename
         input_name = pathlib.Path(input[0]).name
@@ -88,16 +106,16 @@ rule test_rsync_f2d:
         # END OF RUN BLOCK
 
 
-
 rule test_rsync_f2f:
     input:
         rules.create_test_file.output,
     output:
         DIR_PROC.joinpath("testing", "rsync-f2f-ok.txt"),
+    params:
+        acc_out=lambda wildcards, output: register_result(output),
     run:
         rsync_f2f(input[0], output[0])
         # END OF RUN BLOCK
-
 
 
 rule test_rsync_fail:
@@ -107,6 +125,8 @@ rule test_rsync_fail:
         DIR_PROC.joinpath("testing", "rsync-fail-ok.txt"),
     message:
         "EXPECTED FAILURE: ignore following rsync error message"
+    params:
+        acc_out=lambda wildcards, output: register_result(output),
     run:
         import subprocess
 
@@ -118,10 +138,15 @@ rule test_rsync_fail:
         # END OF RUN BLOCK
 
 
-
 rule test_git_labels:
+    input:
+        rules.test_rsync_f2d.output,
+        rules.test_rsync_f2f.output,
+        rules.test_rsync_fail.output,
     output:
-        DIR_PROC.joinpath("testing", "git-labels-ok.txt"),
+        out=DIR_PROC.joinpath("testing", "git-labels-ok.txt"),
+    params:
+        acc_out=lambda wildcards, output: register_result(output.out),
     run:
         git_labels = collect_git_labels()
         with open(output[0], "w") as labels:
@@ -130,31 +155,27 @@ rule test_git_labels:
         # END OF RUN BLOCK
 
 
-
 if USE_REFERENCE_CONTAINER:
     CONTAINER_TEST_FILES = [
         DIR_GLOBAL_REF.joinpath("genome.fasta.fai"),
-        "cache/refcon/refcon_manifests.cache",
+        DIR_PROC.joinpath(".cache", "refcon", "refcon_manifests.cache"),
     ]
+    REGISTER_REFERENCE_FILE = CONTAINER_TEST_FILES[0]
 else:
     CONTAINER_TEST_FILES = []
+    REGISTER_REFERENCE_FILE = []
 
 
-rule aggregate_tests:
+rule trigger_tests:
     input:
-        rules.create_test_file.output,
-        rules.test_log_functions.output,
-        rules.test_find_script_success.output,
-        rules.test_find_script_fail.output,
-        rules.test_rsync_f2f.output,
-        rules.test_rsync_f2d.output,
-        rules.test_rsync_fail.output,
         rules.test_git_labels.output,
         CONTAINER_TEST_FILES,
     output:
         DIR_RES.joinpath("testing", "all-ok.txt"),
+    params:
+        acc_out=lambda wildcards, output: register_result(output),
+        acc_ref=lambda wildcards, input: register_reference(REGISTER_REFERENCE_FILE),
     run:
         with open(output[0], "w") as testfile:
             testfile.write("ok")
         # END OF RUN BLOCK
-


### PR DESCRIPTION
This PR introduces substantial changes:
- add functionality to automatically create a complete file manifest (prepared only during pipeline dry runs, necessary jobs then executed during next actual run)
- add docs/ subfolder, documentation starts to get lengthy; may need further splits in the future
- include some explicit comments in pyutils to logically group functions (also move ref-con related functions here now to get rid of snakemake linting messages)
- required to extract dry run information: introduced new commons module as workflow "staging" area: perform task before actual workflow execution starts