### PR TITLE
Fix #15: accounting files may be optional

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,14 +1,29 @@
 include: "rules/commons/00_commons.smk"
 include: "rules/00_modules.smk"
+include: "rules/99_aggregate.smk"
 
 
 rule run_all:
+    """ The WORKFLOW_OUTPUT
+    target is updated in the
+    99_aggregate.smk module.
+    """
     input:
         RUN_CONFIG_RELPATH,
         MANIFEST_RELPATH,
-        # add output of final rule(s) here
-        # to trigger complete run
-        [],
+        WORKFLOW_OUTPUT,
+
+
+rule run_all_no_manifest:
+    """ Rule added for the
+    unexpected case that no
+    manifest file shall be
+    created (e.g., testing)
+    Part of gh#15 fix.
+    """
+    input:
+        RUN_CONFIG_RELPATH,
+        WORKFLOW_OUTPUT,
 
 
 onsuccess:

--- a/workflow/rules/99_aggregate.smk
+++ b/workflow/rules/99_aggregate.smk
@@ -1,0 +1,14 @@
+"""
+Use this module to extend the default
+workflow output (a list of target files)
+per sub-module.
+The WORKFLOW_OUTPUT list is referenced
+in the main Snakefile
+"""
+
+WORKFLOW_OUTPUT = []
+# Example for extending the output
+# with output from another module
+# (remember to include that module
+# in 00_modules.smk):
+# WORKFLOW_OUTPUT.extend(MODULE_OUTPUT)

--- a/workflow/rules/commons/01_constants.smk
+++ b/workflow/rules/commons/01_constants.smk
@@ -55,6 +55,19 @@ WORKDIR = DIR_WORKING
 RUN_IN_DEV_MODE = config.get("devmode", False)
 assert isinstance(RUN_IN_DEV_MODE, bool)
 
+# if the name of the snakefile is "snaketests" and the
+# developer has not set the devmode option, print a hint
+# to help diagnose path resolution errors
+if NAME_SNAKEFILE == "snaketests" and not RUN_IN_DEV_MODE:
+    hint_msg = "\nDEV HINT:\n"
+    hint_msg += "You are executing the 'snaketests' pipeline,"
+    hint_msg += " but you did not set the config option:\n"
+    hint_msg += " '--config devmode=True'\n"
+    hint_msg += "This may lead to FileNotFoundErrors for the"
+    hint_msg += " subfolders expected to exist"
+    hint_msg += " (proc/, results/ and so on) in the working directory.\n\n"
+    sys.stderr.write(hint_msg)
+
 # should the accounting files be reset?
 RESET_ACCOUNTING = config.get("resetacc", False)
 assert isinstance(RESET_ACCOUNTING, bool)

--- a/workflow/rules/commons/01_constants.smk
+++ b/workflow/rules/commons/01_constants.smk
@@ -36,6 +36,7 @@ ENV_MODULE_SINGULARITY = config.get("env_module_singularity", "Singularity")
 
 DIR_SNAKEFILE = pathlib.Path(workflow.basedir).resolve(strict=True)
 PATH_SNAKEFILE = pathlib.Path(workflow.main_snakefile).resolve(strict=True)
+NAME_SNAKEFILE = PATH_SNAKEFILE.stem
 assert DIR_SNAKEFILE.samefile(PATH_SNAKEFILE.parent)
 
 # in principle, a workflow does not have to make use of scripts,

--- a/workflow/rules/commons/05_refcon.smk
+++ b/workflow/rules/commons/05_refcon.smk
@@ -59,5 +59,7 @@ if USE_REFERENCE_CONTAINER:
                 merged_manifests, axis=0, ignore_index=False
             )
 
-            merged_manifests.to_csv(output.cache, header=True, index=False, sep="\t")
+            merged_manifests.to_csv(
+                output.cache, header=True, index=False, sep="\t"
+            )
             # END OF RUN BLOCK


### PR DESCRIPTION
Closes #15 

- Accounting files are optional by explicit choice: a warning/info message is raised if no accounting files are in use. The user then has the choice to select a different target for the pipeline run (in the default case, `run_all_no_manifest` instead of `run_all`)
- Enabling the same functionality for the testing Snakemake pipeline (`snaketests`) required introducing a new constant for the Name of the main Snakefile 06b69ed0cd3beee64d89071cdac9d41fff0879a5. In the testing case, the alternative target is `run_tests_no_manifest`. This enabled adding a hint printed on screen in case the testing pipeline is executed w/o setting the `devmode=True` option 838dd39e44926fc57c53c1878435306c28982417.
- Change in formatting in refcon module is a result of the snakefmt update 79b787acfb0e1644a440bd5f7799981f7a3e0f2f (see also #20 )