### PR TITLE
fix gh#16 recreate cluster log folders

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -27,8 +27,9 @@ rule run_all_no_manifest:
 
 
 onsuccess:
-    shell(f"rm -rf {DIR_CLUSTERLOG_OUT}")
-    shell(f"rm -rf {DIR_CLUSTERLOG_ERR}")
+    if any([DIR_CLUSTERLOG_OUT.is_dir(), DIR_CLUSTERLOG_ERR.is_dir()]):
+        shell(f"rm -rf {DIR_CLUSTERLOG_OUT} && mkdir -p {DIR_CLUSTERLOG_OUT}")
+        shell(f"rm -rf {DIR_CLUSTERLOG_ERR} && mkdir -p {DIR_CLUSTERLOG_ERR}")
     shell(f"rm -f {RUN_CONFIG_RELPATH.with_suffix('.bak.yaml')}")
 
 


### PR DESCRIPTION
Closes #16 

- Determining whether or not the pipeline is running on a cluster seems a bit too involved for a simple thing like this: if any of the cluster log folders exists, then they will be deleted and recreated upon successful execution