### PR TITLE
fix for gh#17: add support for config parameters (run) suffix

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -10,6 +10,7 @@ rule run_all:
     """
     input:
         RUN_CONFIG_RELPATH,
+        COPY_SAMPLE_SHEET_RELPATH,
         MANIFEST_RELPATH,
         WORKFLOW_OUTPUT,
 
@@ -23,6 +24,7 @@ rule run_all_no_manifest:
     """
     input:
         RUN_CONFIG_RELPATH,
+        COPY_SAMPLE_SHEET_RELPATH,
         WORKFLOW_OUTPUT,
 
 

--- a/workflow/snaketests.smk
+++ b/workflow/snaketests.smk
@@ -16,6 +16,7 @@ WORKFLOW_OUTPUT.extend(
 rule run_tests:
     input:
         RUN_CONFIG_RELPATH,
+        COPY_SAMPLE_SHEET_RELPATH,
         MANIFEST_RELPATH,
         WORKFLOW_OUTPUT
 
@@ -23,6 +24,7 @@ rule run_tests:
 rule run_tests_no_manifest:
     input:
         RUN_CONFIG_RELPATH,
+        COPY_SAMPLE_SHEET_RELPATH,
         WORKFLOW_OUTPUT
 
 


### PR DESCRIPTION
Closes #17 

- Added the config option `suffix`:
```
--config suffix=VALUE
```
where VALUE defaults to `""` and supports the special value `derive`, triggering to use the name of the sample sheet (without `.tsv` file extension) as suffix. In any case, the suffix is processed by (i) replacing all dots and underscores with hyphens/minus, (ii) replacing all duplicated hyphens/minus by a single one, and (iii) only retaining letters, digits and hyphen/minus (this is to avoid silly characters in filenames). The suffix is appended to the manifest file and the run config dump.