### PR TITLE
Update docs (+ merge error)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,123 +2,36 @@
 
 Describe the purpose of the workflow (the big picture)
 
-## General concepts
+## User documentation
 
-### Folder structure
+All standard workflows of the CUBI implement the same user
+interface (or at least aim for a highly similar interface).
+Hence, before [executing the workflow](concepts/running.md),
+we strongly recommend reading the through the documentation
+that explains how we help you to keep track of your analysis
+results; we refer to this concept as
+[**"file accounting"**](concepts/accounting.md). This feature
+of standard CUBI workflows enables the pipeline to auto-
+matically create a so-called [**"manifest"** file](concepts/folders.md)
+for your analysis run.
 
-By following the below guides, you will end up with a Snakemake
-working directory (for short: `wd`) with the following subfolders:
+In case of questions, please open a GitHub issue in the repository
+of the workflow you are trying to execute.
 
-`wd/results/`: this folder contains final results and some workflow metadata
-and represents the only relevant output folder from the end user perspective.
-Accidentally deleting this folder after a successful pipeline run means you have to
-restart the pipeline and Snakemake will check which result files have to be recreated.
+**Note to developers**: the above is the templated user documentation;
+make sure to update or link to additional documentation, e.g.
+describing workflow-specific parameters etc.
 
-`wd/proc/`: the `processing` folder contains intermediate files
-and is not of interest to end users. As a design principle, deleting this
-folder after successful pipeline execution must not result in the loss of
-any relevant data.
+## Developer documentation
 
-The folders `wd/log/` (log files), `wd/rsrc/` (resource/benchmark files) and both
-reference data folders (`wd/global_ref/` and `wd/local_ref/`) should not contain
-any processed sample data (clean design), and are only relevant for workflow developers.
+Besides reading the user documentation, CUBI developers find more
+information regarding standadized workflow development in the
+[developer notes](concepts/developing.md). Please keep in mind
+to always cross-link that information with the guidelines
+published in the
+[CUBI knowledge base](https://github.com/core-unit-bioinformatics/knowledge-base/wiki/).
 
-### Accounting: the file manifest
-
-If properly set up, each workflow automatically creates a result file
-named `manifest.tsv` (in the folder `wd/results/`). This
-file lists all (i) input, (ii) reference (from `wd/global_ref/`) and (iii)
-result files together with metadata such as file size and data checksums
-(both MD5 and SHA256). This file is of utmost importance to track which
-input files in conjunction with which reference files were used to produce
-a certain set of result files. Never-ever delete this file.
-
-**Important** Preparing the computation of all checksums etc. that are needed
-to complete the file manifest, is done during a `--dryrun` of the pipeline. If you
-are sure that the pipeline will run start to finish, run Snakemake with the
-option `--dryrun` twice before actually starting the computations. This will
-ensure that all metadata files (checksums etc.) will be known to Snakemake
-when the pipeline run starts and will be created as part of the regular flow
-of computations.
-
-### Rerunning the exact same workflow
-
-By default, after a successful pipeline run, a complete dump of the workflow
-configuration is written to a file named `run_config.yaml` (in the folder
-`wd/results/`). This configuration dump includes the information which user
-executated the workflow and which (code) version of the worklow was used.
-Assuming that the execution infrastructure (i.e., the compute cluster) is
-the same, it is possible to use just this configuration file to rerun the workflow
-in the exact same way. Never-ever delete this file.
-
-## Documentation for users
-
-If you want to use this workflow as a black box to process your data,
-simply follow the below series of steps to get things up and running.
-
-### Deploying the workflow on execution hardware
-
-1. run `./init.py` (requires Python3)
-    - this will create an "execution" Conda environment,
-    and a Snakemake working directory plus standard subfolders
-    one level above the repository location
-2. activate the created Conda environment: `cd .. && conda activate ./exec_env`
-3. prepare profile and configuration files as necessary, and run Snakemake
-
-
-### Detailed output specification
-
-For detailed descriptions, this should be moved in a separate markdown file.
-
-## Documentation for developers
-
-### Developing the workflow locally
-
-1. run `./init.py --dev-only` (requires Python3)
-    - this will skip creating the workflow working directory and subfolders
-2. activate the created Conda environment: `conda activate ./dev_env`
-3. write your code, and add tests to `workflow/snaketests.smk`
-4. run tests:
-    - note that some tests may be expected to fail and may produce error messages
-    - if Snakemake reports a successful pipeline run, then all tests have succeeded
-      irrespective of log messages that look like errors
-    - if you want to test the functions loading reference data from reference containers,
-      you need to build the test container `test_v0.sif` and copy it into the
-      working directory for the workflow test run. Refer to the
-      [reference container repository](https://github.com/core-unit-bioinformatics/reference-container)
-      for build instructions.
-
-```bash
-# Example: test w/o reference container
-# Note: execute the workflow first in
-# '--dryrun' mode to trigger (and test)
-# the complete MANIFEST creation
-snakemake --cores 1 \
-    [--dryrun] \
-    --config devmode=True \
-    --directory wd/ \
-    --snakefile workflow/snaketests.smk
-
-# Example: test w/ reference container;
-# the container 'test_v0.sif' must exist
-# in the working directory: 'wd/test_v0.sif'
-# Note: execute the workflow first in
-# '--dryrun' mode to trigger (and test)
-# the complete MANIFEST creation
-snakemake --cores 1 \
-    [--dryrun] \
-    --config devmode=True \
-    --directory wd/ \
-    --configfiles config/testing/params_refcon.yaml \
-    --snakefile workflow/snaketests.smk
-```
-    
-5. run the recommended code checks with the following tools:
-    - Python scripts:
-        - linting: `pylint <script.py>`
-        - organize imports: `isort <script.py>`
-        - code formatting: `black [--check] .`
-    - Snakemake files:
-        - linting: `snakemake --config devmode=True --lint`
-        - code formatting: `snakefmt [--check] .`
-6. after checking and standardizing your code, commit and push your changes
+Please raise any issues with these guidelines "close to the code",
+i.e., either open an issue in the
+[knowledge base repo](https://github.com/core-unit-bioinformatics/knowledge-base)
+or in the affected repo for more specific cases.

--- a/docs/concepts/accounting.md
+++ b/docs/concepts/accounting.md
@@ -1,0 +1,117 @@
+# File accounting and manifest creation
+
+A vital piece of information needed to trace problems
+to their source and to "just know what has been done"
+is the knowledge about all files that were processed
+and generated as part of the workflow. In simple terms,
+it is mandatory to keep a complete record of all input,
+output/result and potential reference files for each
+workflow run.
+
+In the context of the CUBI, the process of generating
+this comprehensive record is termed **"(file) accounting"**.
+The automatically generated accounting information is then
+combined to generate the so-called **manifest file**.
+
+The **manifest file** contains the basic info (name, source,
+size, checksums) of all of the above mentioned file types, i.e.,
+input, output/result and reference files. The information is
+stored as a tab-separated text file (a TSV table).
+
+The **manifest file** will be created in the snakemake
+working directory, with the name potentially modified by
+a user-supplied suffix (via the `--config suffix=SUFFIX`)
+option:
+
+```
+# default name
+wd/manifest.tsv
+
+# name modified with suffix
+wd/manifest.SUFFIX.tsv
+```
+
+## How to generate the manifest file?
+
+For technical reasons, the file accounting only happens
+during a Snakemake dry run. After executing the workflow
+twice in dry run mode, all information needed for the
+accounting has been collected, and the necessary jobs
+(obtaining file sizes, computing checksums etc.) are known
+to Snakemake and will be processed together with the regular
+data analysis tasks.
+
+The option to execute a dry run of the workflow is the
+`-n` (or `--dry-run`) parameter:
+
+```
+# execute this twice
+snakemake -n [...other options...] run_all
+
+# afterwards, start the run, the manifest
+# will be created automatically
+snakemake [...other options...] run_all
+```
+
+## Troubleshooting: broken file accounting
+
+After the file accounting information has been collected,
+Snakemake knows what jobs need to be processed (= which
+files to generate). If, however, one of the data files
+is changed (say, renamed), the file accounting will break
+because the original accounting information can no longer
+be generated. Consider the following (simplified) example:
+
+```
+# a data file in the workflow gives rise
+# to several supplementary files needed
+# for the accounting
+file_A.data
+
+# the following is just accounting info
+# derived using file_A.data as input
+file_A.size
+file_A.source
+file_A.checksum
+```
+
+Assuming `file_A.data` was renamed, the following will happen:
+
+```
+# the renamed file
+file_B.data
+
+# new accounting info
+file_B.size
+file_B.source
+file_B.checksum
+
+# however, the following accounting info is still
+# registered, but cannot be created because
+# file_A.data does not exist any more
+file_A.size
+file_A.source
+file_A.checksum
+```
+
+In this situation, Snakemake would fail with the error that there are
+missing input files (here: `file_A.data` is no longer present), and files
+dependent on that input thus cannot be produced. This can be fixed by
+resetting and recreating all accounting files:
+
+```
+# dry run one including the config option to
+# reset the accounting information
+snakemake [...other options...] -n --config resetacc=True
+
+# dry run two after the reset as usual
+snakemake [...other options...] -n
+```
+
+## Troubleshooting: it just does not work
+
+If the manifest creation just seems impossible, (i) please get in
+touch; then, instead of targeting the rule `run_all` when
+executing Snakemake, (ii) please target the rule `run_all_no_manifest`.
+This rule excludes the manifest creation and no problems related
+to that should stop you from proceeding with your analysis.

--- a/docs/concepts/developing.md
+++ b/docs/concepts/developing.md
@@ -1,0 +1,85 @@
+# For CUBI developers
+
+The following information is only relevant for CUBI developers,
+and is further contextualized via the guidelines listed in
+the [CUBI knowledge base](https://github.com/core-unit-bioinformatics/knowledge-base).
+
+## Developing a Snakemake workflow locally
+
+A more detailed explanation of the workflow setup process
+can be found in the [user documentation](./running.md) for
+running a workflow.
+
+In brief, ...
+
+1. run `./init.py --dev-only` (requires Python3)
+    - this will skip creating the workflow working directory and subfolders
+2. activate the created Conda environment: `conda activate ./dev_env`
+3. write your code, and add tests to `workflow/snaketests.smk`
+4. run tests:
+    - note that some tests may be expected to fail and may produce error messages
+    - if Snakemake reports a successful pipeline run, then all tests have succeeded
+      irrespective of log messages that look like errors
+    - if you want to test the functions loading reference data from reference containers,
+      you need to build the test container `test_v0.sif` and copy it into the
+      working directory for the workflow test run. Refer to the
+      [reference container repository](https://github.com/core-unit-bioinformatics/reference-container)
+      for build instructions.
+
+```bash
+# Example: test w/o reference container
+# Note: execute the workflow first in
+# '--dryrun' mode twice to trigger
+# (and test) the complete MANIFEST
+# creation
+snakemake --cores 1 \
+    [--dryrun] \
+    --config devmode=True \
+    --directory wd/ \
+    --snakefile workflow/snaketests.smk \
+    run_tests
+
+# Example: test w/ reference container;
+# the container 'test_v0.sif' must exist
+# in the working directory: 'wd/test_v0.sif'
+# Note: execute the workflow first in
+# '--dryrun' mode twice to trigger
+# (and test) the complete MANIFEST
+# creation
+snakemake --cores 1 \
+    [--dryrun] \
+    --config devmode=True \
+    --directory wd/ \
+    --configfiles config/testing/params_refcon.yaml \
+    --snakefile workflow/snaketests.smk \
+    run_tests
+```
+
+Note that if there are problems related to creating the
+MANIFEST, you can first check if all other tests pass
+by targeting the rule `run_tests_no_manifest`.
+
+## Code style and checks
+
+Please read the knowledge base articles on
+[naming conventions and code style/format](https://github.com/core-unit-bioinformatics/knowledge-base/wiki/Naming-and-style).
+
+The following helpers should be executed before committing and
+pushing code to shared repositories:
+
+1. Python scripts
+  - MUST: linting: `pylint <script.py>`
+  - SHOULD: organize imports: `isort <script.py>`
+  - MUST: code formatting: `black [--check] <script.py>`
+2. Snakemake workflow
+  - MUST: code formatting `snakefmt [--check] <snakefile>`
+    - note: the Snakemake formatter has some issues and sometimes
+      violates Python formatting rules (see here:
+      [gh#20](https://github.com/core-unit-bioinformatics/template-snakemake/issues/20)).
+      The output should be manually checked and obvious idiosyncracies
+      fixed before committing the code.
+  - MAY: linting: `snakemake --config devmode=True --lint`
+    - note: the Snakemake linter hardly produces overly helpful
+      hints to improve the code quality of the Snakefile.
+      Give it a try and see for yourself.
+3. R scripts: tools for linting/formatting are open issues

--- a/docs/concepts/folders.md
+++ b/docs/concepts/folders.md
@@ -1,0 +1,50 @@
+# Workflow folder structure
+
+The default layout for the Snakemake working directory, i.e.
+the directory specified with the option `--directory` / `-d`
+when invoking `snakemake`, is standardized to ease navigating
+through the subfolders. In the following, the abbreviation
+WD is used to refer to that directory.
+
+If you followed the CUBI recommendation and created your
+Snakemake WD with the `init.py` script from the workflow
+repository, the WD will have been created one level above
+the workflow repository location (where the `init.py`
+script resides).
+
+Inside the WD, you find several subfolders ...
+
+## Users: continue reading here
+
+The only subfolder relevant to you is called
+`results/`. This folder contains all important
+result files of the analysis, plus two
+special files (`manifest*` and `run_config*`)
+that you should never delete, but can ignore.
+The entire content of the `results/` folder should
+be saved in a secure location (with backup). Deleting
+any other folder inside the WD does not affect your results,
+but may cause delays if the analysis run is changed
+or continued later on - so please be sure that the
+analysis is complete before deleting anything.
+
+## Developers: continue reading here
+
+By convention, a pipeline must sort all data files
+into one of the following folders:
+
+- `proc/`: processing; intermediate/temp data files, not vital
+- `results/`: everything relevant to the client/user
+  - automatically contains a copy of the sample sheet,
+    the manifest file, and a dump of the run config
+- `global_ref/`: global reference files either loaded from
+    reference containers or *ex nihilo*, i.e. references
+    manually placed in the pipeline context
+- `local_ref/`: reference data local to the pipeline context,
+    e.g. postprocessed files generated as part of the run
+- `log/`: target for Snakemake `log:` files
+- `rsrc/`: target for Snakemake `benchmark:` files
+
+There are a few other standard directories defined that you must
+use if needed. See the Snakemake module `workflow/rules/common/10_constants.smk`
+for a complete list.

--- a/docs/concepts/running.md
+++ b/docs/concepts/running.md
@@ -1,0 +1,81 @@
+# Executing a standard CUBI workflow
+
+## Snakemake
+
+Snakemake workflows that implement the default interface of the
+CUBI can always be deployed in the same way. The following steps
+outline the recommended process:
+
+1. create a directory for the project (`project_dir/`)
+2. clone the workflow repository into that directory, and
+   checkout the version of the workflow you want to run
+   (if applicable)
+    ```bash
+    project_dir/
+        |
+        --- workflow_repository/
+                |
+                --- init.py
+    ```
+3. run the `init.py` script from inside the workflow repository
+    - **attention**: by default, the `init.py` script attempts to create
+      a [Conda environment](https://docs.conda.io/projects/conda/en/latest/index.html)
+      containing all necessary tools to execute the workflow
+      (that is essentially Snakemake plus a few dependencies).
+      This part of the setup requires a working Conda installation
+      including a proper configuration of Conda to make use of the
+      [`bioconda` channel](https://bioconda.github.io/).
+    - if you don't want to make use of Conda environments to run
+      the workflow, please make sure that all software dependencies
+      listed in the [`exec_env.yaml`](../../workflow/envs/exec_env.yaml)
+      environment specification are available on your system.
+4. the `init.py` script will create the following directories
+    ```bash
+    project_dir/
+        |
+        --- workflow_repository/
+        |       |
+        |       --- init.py
+        |
+        --- wd/  # the working directory for Snakemake
+        --- exec_env/  # the Conda execution environment
+    ```
+5. activate the Conda execution environment: `conda activate ./exec_env`
+6. if applicable, prepare the Snakemake profile for your compute infrastructure
+    - HHU-internal users: you can make use of a small utility maintained
+      by the CUBI that automates creating Snakemake profiles for the compute
+      infrastructure at HHU/UKD [snakemake-utils@HHU GitLab](https://git.hhu.de/cubi/snakemake-utils)
+7. prepare the sample data information (the so-called "sample sheet") as a
+   plain text tab-separated table ("*.tsv"). Please refer to the specific
+   workflow documentation to learn what data the respective workflow needs
+   as input.
+8. run the workflow from inside the workflow repository as follows:
+    ```bash
+    snakemake -n \  # start with a dry run
+        -d ../wd/ \  # the working directory as created above
+        --configfiles [...] \  # parameters for the workflow
+        --config samples=PATH/TO/SAMPLE-SHEET.tsv \  # recommended: use an absolute path
+        --profile PATH/TO/SNAKEMAKE-PROFILE/ \
+        run_all  # create all result files specified in the workflow
+    ```
+    - note that executing the workflow first in dry run mode is strongly
+      recommended to check if the setup process worked as expected. Moreover,
+      running the workflow *twice* in dry run mode is required to create
+      the [manifest output](./accounting.md) of the workflow.
+9. collect the important workflow output from the `results/` folder:
+    ```bash
+    project_dir/
+        |
+        --- workflow_repository/
+        |       |
+        |       --- init.py
+        |
+        --- wd/
+             |
+             --- results/
+        --- exec_env/
+    ```
+    - the `results/` folder also contains other important information
+      besides the analysis output. Please refer to the description of
+      the [standard folder layout](./folders.md) of the working
+      directory to find more information.


### PR DESCRIPTION
- updates user and dev docs in "docs/"
- due to a local mixup when pulling and merging updates, this PR should have include 482f0c06f75603ebfc8f9df6f86f903a92ae89c9 and af22fda088b52c90ccab7a26cf623c234dc8a786 that are obviously a major part of the introduced changes
- show help via rule `show_help` or built target `show-help (`commons::50_smkutils.smk`)
- add description of supported (user) config options via `commons::20_config_options.smk`
- new module `commons::10_constants.smk` listing file and directory constants (fixed paths)